### PR TITLE
Improve clear and declarative language for API syntax.

### DIFF
--- a/src/Types.luau
+++ b/src/Types.luau
@@ -23,6 +23,21 @@ export type State<T = any> = Observable<T> & typeof(setmetatable(
 		Set: (self: State<T>, T) -> (),
 	}}
 ))
+export type Spring<T = any> = Observable<T> & typeof(setmetatable(
+	{} :: {
+		_angularFrequency: number,
+		_current: number,
+		_target: number,
+		_snapToGoalTheshold: number?,
+	},
+	{} :: {__index: {
+		SetAngularFrequency: (self: State<T>, number) -> (),
+		CurrentAngularFrequency: (self: State<T>) -> number,
+		SetTarget: (self: State<T>, target: T) -> (),
+		CurrentTarget: (self: State<T>) -> T,
+		SetPosition: (self: State<T>, position: T) -> (),
+	}}
+))
 export type Alpha = Observable<number> & typeof(setmetatable(
 	{} :: {},
 	{} :: {__index: {
@@ -62,6 +77,12 @@ export type Timer = BaseTimer & typeof(setmetatable(
 	}}
 ))
 export type CanBeObservable<T = any> = T | Observable<T>
+export type Tween = {
+	info: TweenInfo,
+	start {[string]: any}?,
+	goal = {[string]: any},
+	completed: (() -> ())?,
+}
 export type VirtualInstance = typeof(setmetatable(
 	{} :: {
 		_current: Instance?,
@@ -75,9 +96,7 @@ export type VirtualInstance = typeof(setmetatable(
 		) -> (),
 		Tweens: (
 			self: VirtualInstance,
-			info: CanBeObservable<TweenInfo>,
-			goalProperties: CanBeObservable<{[string]: CanBeObservable<any>}?>,
-			startProperties: CanBeObservable<{[string]: CanBeObservable<any>}?>
+			Fusion.CanBeObservable<{Tween}>
 		) -> (),
 		Attributes: (
 			self: VirtualInstance,
@@ -168,6 +187,7 @@ export type Root = typeof(setmetatable(
 type Dec = {
 	-- State and Observable Utilities
 	State: <T>(initial: T) -> State<T>,
+	Spring: <T>(initial: T) -> Spring<T>,
 	Stopwatch: () -> Stopwatch,
 	Timer: (duration: number) -> Timer,
 	Derive: (<Return, D1>(

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -77,12 +77,24 @@ export type Timer = BaseTimer & typeof(setmetatable(
 	}}
 ))
 export type CanBeObservable<T = any> = T | Observable<T>
-export type Tween = {
+export type TweenState = Observable<{
 	info: TweenInfo,
-	start {[string]: any}?,
-	goal = {[string]: any},
+	startProps: {[string]: any}?,
+	goalProps: {[string]: any},
 	completed: (() -> ())?,
-}
+}> & typeof(setmetatable(
+	{} :: {
+		_currentTween: Tween?,
+	},
+	{} :: {__index: {
+		Start: (self: TweenState) -> (),
+		Cancel: (self: TweenState) -> (),
+		SetGoal: (self: TweenState, goalProps: {[string]: any}) -> (),
+		SetInfo: (self: TweenState, info: TweenInfo) -> (),
+		SetStart: (self: TweenState, startProps: {[string]: any}?) -> (),
+		SetOnCompleted: (self: TweenState, cb: (() -> ())?) -> (),
+	}}
+))
 export type VirtualInstance = typeof(setmetatable(
 	{} :: {
 		_current: Instance?,
@@ -96,7 +108,7 @@ export type VirtualInstance = typeof(setmetatable(
 		) -> (),
 		Tweens: (
 			self: VirtualInstance,
-			Fusion.CanBeObservable<{Tween}>
+			TweenState | {TweenState}
 		) -> (),
 		Attributes: (
 			self: VirtualInstance,
@@ -190,6 +202,7 @@ type Dec = {
 	Spring: <T>(initial: T) -> Spring<T>,
 	Stopwatch: () -> Stopwatch,
 	Timer: (duration: number) -> Timer,
+	Tween: (info: TweenInfo, goalProps: {[string]: any}, startProps: {[string]: any}?) -> TweenState,
 	Derive: (<Return, D1>(
 		dep1: Observable<D1>,
 		map: (dep1: D1) -> Return
@@ -229,10 +242,10 @@ type Dec = {
 	Existing: (template: Instance | VirtualInstance) -> VirtualInstance,
 	
 	-- Root-Level Reconciler API
-	CreateRoot: (instance: Instance) -> Root
+	CreateRoot: (instance: Instance) -> Root,
 	
 	-- Symbols
-	Nil: {}
+	Nil: Symbol<"Nil">,
 }
 
 return nil

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -239,7 +239,7 @@ type Dec = {
 	-- VirtualInstance Creators
 	New: (className: string) -> VirtualInstance,
 	Clone: (template: Instance) -> VirtualInstance,
-	Existing: (template: Instance | VirtualInstance) -> VirtualInstance,
+	Premade: () -> VirtualInstance,
 	
 	-- Root-Level Reconciler API
 	CreateRoot: (instance: Instance) -> Root,

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -209,7 +209,7 @@ type Dec = {
 	Existing: (template: Instance | VirtualInstance) -> VirtualInstance,
 	
 	-- Root-Level Reconciler API
-	CreateRoot: (instance: Instance) -> DecRoot
+	CreateRoot: (instance: Instance) -> Root
 	
 	-- Symbols
 	Nil: {}

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -14,7 +14,6 @@ export type Observable<T = any> = typeof(setmetatable(
 		_dectype: string,
 		Subscribe: (self: Observable<T>, listener: (T) -> ()) -> Unsubscribe,
 		Current: (self: Observable<T>) -> T,
-		DeferUpdates: (self: Observable<T>) -> Observable<T>,
 		Destroy: (self: Observable<T>) -> (),
 	}}
 ))
@@ -35,32 +34,31 @@ export type Alpha = Observable<number> & typeof(setmetatable(
 		) -> Alpha
 	}}
 ))
-export type Stopwatch = Observable<number> & typeof(setmetatable(
+export type BaseTimer = Observable<number> & typeof(setmetatable(
 	{} :: {
 		_stepConnection: RBXScriptConnection?,
 		_resumeAt: number?,
 	},
 	{} :: {__index: {
-		Alpha: (self: Stopwatch, endElapsedTime: number) -> Alpha,
-		Start: (self: Stopwatch) -> (),
-		Stop: (self: Stopwatch) -> (),
-		Pause: (self: Stopwatch) -> (),
-		Resume: (self: Stopwatch) -> (),
+		Start: (self: BaseTimer) -> (),
+		Stop: (self: BaseTimer) -> (),
+		Pause: (self: BaseTimer) -> (),
+		Resume: (self: BaseTimer) -> (),
 	}}
 ))
-export type Timer = Observable<number> & typeof(setmetatable(
+export type Stopwatch = BaseTimer & typeof(setmetatable(
+	{} :: { },
+	{} :: {__index: {
+		Alpha: (self: Stopwatch, endElapsedTime: number) -> Alpha,
+	}}
+))
+export type Timer = BaseTimer & typeof(setmetatable(
 	{} :: {
-		_stepConnection: RBXScriptConnection?,
-		_resumeAt: number?,
 		_duration: Observable<number>,
 	},
 	{} :: {__index: {
 		SetDuration: (self: Timer) -> (),
 		Alpha: (self: Timer) -> Alpha,
-		Start: (self: Timer) -> (),
-		Stop: (self: Timer) -> (),
-		Pause: (self: Timer) -> (),
-		Resume: (self: Timer) -> (),
 	}}
 ))
 export type CanBeObservable<T = any> = T | Observable<T>

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -109,25 +109,16 @@ export type VirtualInstance = typeof(setmetatable(
 			outState: CanBeObservable<State<Instance> | State<Instance?>>
 		) -> (),
 		Copy: (self: VirtualInstance) -> VirtualInstance,
-		NewChildren: (
+		Children: (
 			self: VirtualInstance,
 			childMap: CanBeObservable<{
 				[string | number]: CanBeObservable<Instance | VirtualInstance>
 			}>
 		) -> (),
-		NewChild: (
+		Child: (
 			self: VirtualInstance,
 			child: CanBeObservable<Instance | VirtualInstance>,
 			name: CanBeObservable<string?>
-		) -> (),
-		ExistingChild: (
-			self: VirtualInstance,
-			path: CanBeObservable<string | {string}>,
-			child: CanBeObservable<Instance | VirtualInstance>
-		) -> (),
-		ExistingChildren: (
-			self: VirtualInstance,
-			pathMap: CanBeObservable<{[string]: CanBeObservable<VirtualInstance>}
 		) -> (),
 		OnMount: (
 			self: VirtualInstance,

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -131,7 +131,7 @@ export type VirtualInstance = typeof(setmetatable(
 		propertyMap: CanBeObservable<{[string]: any}>
 	) -> VirtualInstance}
 ))
-export type Reconciled = typeof(setmetatable(
+export type ReconciledNode = typeof(setmetatable(
 	{} :: {
 		_connections: {RBXScriptConnection},
 		_instances: {Instance},
@@ -139,7 +139,7 @@ export type Reconciled = typeof(setmetatable(
 	},
 	{} :: {__index: {
 		_dectype: string,
-		Destroy: (self: Reconciled) -> (),
+		Destroy: (self: ReconciledNode) -> (),
 	}}
 ))
 export type Symbol<Name> = typeof(setmetatable(
@@ -150,6 +150,17 @@ export type Symbol<Name> = typeof(setmetatable(
 	{} :: {__index: {
 		_dectype: string,
 	}, __tostring: (self: Symbol<Name>) -> string}
+))
+export type Root = typeof(setmetatable(
+	{} :: {
+		_instance: Instance,
+		_reconciled: ReconciledNode?
+	},
+	{} :: {_index: {
+		Render: (self: Root, node: VirtualInstance) -> ReconciledNode,
+		Unmount: (self: Root) -> (),
+		Destroy: (self: Root) -> (),
+	}}
 ))
 
 -- Temporary typedef for library; will move typings to the return of component
@@ -198,12 +209,7 @@ type Dec = {
 	Existing: (template: Instance | VirtualInstance) -> VirtualInstance,
 	
 	-- Root-Level Reconciler API
-	Mount: (root: CanBeObservable<VirtualInstance>) -> Reconciled,
-	Replace: (
-		current: Reconciled,
-		new: CanBeObservable<VirtualInstance>
-	) -> VirtualInstance,
-	Unmount: (current: Reconciled) -> (),
+	CreateRoot: (instance: Instance) -> DecRoot
 	
 	-- Symbols
 	Nil: {}

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -71,87 +71,75 @@ export type VirtualInstance = typeof(setmetatable(
 	},
 	{} :: {__index: {
 		_dectype: string,
-		Assign: (
+		Properties: (
 			self: VirtualInstance,
-			propertyMap: {[string]: any}
-		) -> VirtualInstance,
-		Tween: (
+			propertyMap: CanBeObservable<{[string]: any}>
+		) -> (),
+		Tweens: (
 			self: VirtualInstance,
-			info: TweenInfo,
+			info: CanBeObservable<TweenInfo>,
 			goalProperties: CanBeObservable<{[string]: CanBeObservable<any>}?>,
 			startProperties: CanBeObservable<{[string]: CanBeObservable<any>}?>
-		) -> VirtualInstance,
-		SetAttributes: (
+		) -> (),
+		Attributes: (
 			self: VirtualInstance,
-			attributeMap: {[string]: any}
-		) -> VirtualInstance,
-		SetTags: (
+			attributeMap: CanBeObservable<{[string]: any}>
+		) -> (),
+		Tags: (
 			self: VirtualInstance,
-			tags: {string} | Observable<{string}>
-		) -> VirtualInstance,
+			tags: CanBeObservable<{string} | Observable<{string}>
+		) -> (),
 		Connect: (
 			self: VirtualInstance,
 			eventName: string,
 			signal: (...any) -> ()
-		) -> VirtualInstance,
-		StoreProperty: (
+		) -> (),
+		OutProperty: (
 			self: VirtualInstance,
 			propertyName: string,
-			outState: State<any>
-		) -> VirtualInstance,
-		StoreAttribute: (
+			outState: CanBeObservable<State<any>>
+		) -> (),
+		OutAttribute: (
 			self: VirtualInstance,
 			propertyName: string,
-			outState: State<any>
-		) -> VirtualInstance,
-		StoreReference: (
+			outState: CanBeObservable<State<any>>
+		) -> (),
+		OutInstance: (
 			self: VirtualInstance,
-			outState: State<Instance>
-		) -> VirtualInstance,
+			outState: CanBeObservable<State<Instance> | State<Instance?>>
+		) -> (),
 		Copy: (self: VirtualInstance) -> VirtualInstance,
-		AddChildren: (
+		NewChildren: (
 			self: VirtualInstance,
 			childMap: CanBeObservable<{
 				[string | number]: CanBeObservable<Instance | VirtualInstance>
 			}>
-		) -> VirtualInstance,
-		AddChild: (
+		) -> (),
+		NewChild: (
 			self: VirtualInstance,
 			child: CanBeObservable<Instance | VirtualInstance>,
-			name: string?
-		) -> VirtualInstance,
-		AddExistingChild: (
+			name: CanBeObservable<string?>
+		) -> (),
+		ExistingChild: (
 			self: VirtualInstance,
-			path: string | {string},
-			callback: CanBeObservable<(VirtualInstance) -> ()>
-		) -> VirtualInstance,
-		AddToParent: (
+			path: CanBeObservable<string | {string}>,
+			child: CanBeObservable<Instance | VirtualInstance>
+		) -> (),
+		ExistingChildren: (
 			self: VirtualInstance,
-			parent: CanBeObservable<VirtualInstance | Instance>
-		) -> VirtualInstance,
-		-- Lifecycle events (Useful for niche cases like event/effect cleanups
-		-- that can't be handled directly via Dec's virtual instances)
-		OnUnmount: (
-			self: VirtualInstance,
-			callback: (instance: Instance) -> ()
-		) -> VirtualInstance,
+			pathMap: CanBeObservable<{[string]: CanBeObservable<VirtualInstance>}
+		) -> (),
 		OnMount: (
 			self: VirtualInstance,
 			callback: (instance: Instance) -> ()
-		) -> VirtualInstance,
-		Index: (
+		) -> (),
+		OnUnmount: (
 			self: VirtualInstance,
-			path: string | {string}
-		) -> VirtualInstance,
-		
-		--  Linked states
-		CleanupOnUnmount: (
-			self: VirtualInstance,
-			object: any
-		) -> any,
+			callback: (instance: Instance) -> (),
+		) -> (),
 	}, __call: (
 		self: VirtualInstance,
-		propertyMap: {[string]: any}
+		propertyMap: CanBeObservable<{[string]: any}>
 	) -> VirtualInstance}
 ))
 export type Reconciled = typeof(setmetatable(


### PR DESCRIPTION
- Removed redundant/unclear methods in VirtualInstance, Observables.
- Refactored language in VirtualInstance and Observables.
- Removed syntax sugar for self-return on VirtualInstance methods (other than `__call` metamethod). Breaking up into multiple statements is preferred, and matches roblox's syntax better.
- Increased usage of CanBeObservable for dynamic types 
- Child creation, cloning, or masking (find existing) is determined by abstract component itself. Remove redundant Child/Index APIs, and unify as `Child` / `Children` map to a child virtual instance.