### PR TITLE
Initialize Reconciler Structure

### DIFF
--- a/src/Observables/Alpha.luau
+++ b/src/Observables/Alpha.luau
@@ -57,8 +57,7 @@ Alpha.__index.Destroy = Observable.__index.Destroy
 function Alpha.new(initialValue: number): Alpha
     return setmetatable({
         _current = initialValue,
-        -- _consumers = nil,
-        -- _consumersWeak = nil,
+        _observerCount = 0,
     }, Alpha :: any)
 end
 

--- a/src/Observables/BaseTimer.luau
+++ b/src/Observables/BaseTimer.luau
@@ -60,8 +60,7 @@ function BaseTimer.new(): BaseTimer
         _stepConnection = nil,
         _resumeAt = nil,
         _current = 0,
-        -- _consumers = nil,
-        -- _consumersWeak = nil,
+        _observerCount = 0,
     }, BaseTimer :: any)
 end
 

--- a/src/Observables/Observable.luau
+++ b/src/Observables/Observable.luau
@@ -52,8 +52,7 @@ end
 function Observable.new<T>(initialValue: T): Observable<T>
     return setmetatable({
         _current = initialValue,
-		-- _consumers = nil,
-		-- _consumersWeak = nil,
+        _observerCount = 0,
     }, Observable)
 end
 

--- a/src/Observables/Spring.luau
+++ b/src/Observables/Spring.luau
@@ -86,8 +86,7 @@ function Spring.new<T>(initialValue: T, angularFrequency: number): Spring<T>
         _current = initialValue,
         _angularFrequency = angularFrequency,
         _target = initialValue,
-        -- _consumers = nil,
-        -- _consumersWeak = nil,
+        _observerCount = 0,
         -- _snapToGoalTheshold = nil,
     }, Spring :: any)
 end

--- a/src/Observables/State.luau
+++ b/src/Observables/State.luau
@@ -35,8 +35,7 @@ State.__index.Destroy = Observable.__index.Destroy
 function State.new<T>(initialValue: T): State<T>
     return setmetatable({
         _current = initialValue,
-        -- _consumers = nil,
-        -- _consumersWeak = nil,
+        _observerCount = 0,
     }, State :: any)
 end
 

--- a/src/Observables/Stopwatch.luau
+++ b/src/Observables/Stopwatch.luau
@@ -40,8 +40,7 @@ function Stopwatch.new(): Stopwatch
         _stepConnection = nil,
         _resumeAt = nil,
         _current = 0,
-        -- _consumers = nil,
-        -- _consumersWeak = nil,
+        _observerCount = 0,
     }, Stopwatch :: any)
 end
 

--- a/src/Observables/Timer.luau
+++ b/src/Observables/Timer.luau
@@ -56,8 +56,7 @@ function Timer.new(duration: number): Timer
         _stepConnection = nil,
         _resumeAt = nil,
         _current = 0,
-        -- _consumers = nil,
-        -- _consumersWeak = nil,
+        _observerCount = 0,
     }, Timer :: any)
 end
 

--- a/src/Observables/TweenState.luau
+++ b/src/Observables/TweenState.luau
@@ -113,8 +113,7 @@ function TweenState.new(
             completed = completed,
         },
         _currentTween = nil,
-        -- _consumers = nil,
-        -- _consumersWeak = nil,
+        _observerCount = 0,
     }, TweenState :: any)
 end
 

--- a/src/Reconciler/ApplyPropertyMapThrows.luau
+++ b/src/Reconciler/ApplyPropertyMapThrows.luau
@@ -1,0 +1,48 @@
+--!strict
+
+local Types = require(script.Parent.Parent.Types)
+type Set<T> = Types.Set<T>
+
+--[[
+    @param reconciledNode: Dec.ReconciledNode - The reconciled node to apply
+        the property map to. Connections and observable cleanups are stored
+        here.
+    @param propMap: {[string]: any} - The property map to apply to the
+        VirtualInstance.
+    Applies a property map to a VirtualInstance, catching any Roblox engine
+    errors. If an error occurs, it will be logged to the console traced to
+    the line of code where the VirtualInstance was created.
+
+    Certain properties (such as Parent) will be applied last.
+]]
+local KEYS_TO_DEFER: Set<string> = {
+    Parent = true,
+}
+local function ApplyPropertyMapThrows(
+    reconciledNode: Types.ReconciledNode,
+    propMap: {[string]: any}
+)
+    local instance = reconciledNode._instance :: any
+    local reconciledConns = reconciledNode._connections :: any
+    local deferredKeys: {string} = {}
+    for key, value in propMap do
+        if KEYS_TO_DEFER[key] then
+            table.insert(deferredKeys, key)
+            continue
+        end
+
+        if typeof(value) == "function" then
+            table.insert(
+                reconciledConns,
+                instance[key]:Connect(value)
+            )
+        end
+        instance[key] = value
+    end
+
+    for _, key in deferredKeys do
+        instance[key] = propMap[key]
+    end
+end
+
+return ApplyPropertyMapThrows

--- a/src/Reconciler/ApplyPropertyMapThrows.luau
+++ b/src/Reconciler/ApplyPropertyMapThrows.luau
@@ -3,6 +3,11 @@
 local Symbols = require(script.Parent.Parent.Symbols)
 local Types = require(script.Parent.Parent.Types)
 type Set<T> = Types.Set<T>
+local NilSymbol = Symbols.Nil
+
+local function applyNilSymbol(value: any): any
+    return if value == NilSymbol then nil else value
+end
 
 --[[
     @param reconciledNode: Dec.ReconciledNode - The reconciled node to apply
@@ -40,16 +45,13 @@ local function ApplyPropertyMapThrows(
         elseif typeof(value) == "table" and value._dectype == "Observable" then
             table.insert(
                 reconciledConns,
-                value:Subscribe(function(newValue)
-                    local valueToApply = if (newValue == Symbols.Nil :: any)
-                        then nil else newValue
-                    instance[key] = valueToApply
+                value:Subscribe(function(current)
+                    instance[key] = applyNilSymbol(current)
                 end)
             )
-        elseif value == Symbols.Nil then
-            instance[key] = nil
+            instance[key] = applyNilSymbol(value:Current())
         else
-            instance[key] = value
+            instance[key] = applyNilSymbol(value)
         end
     end
 

--- a/src/Reconciler/ApplyPropertyMapThrows.luau
+++ b/src/Reconciler/ApplyPropertyMapThrows.luau
@@ -1,5 +1,6 @@
 --!strict
 
+local Symbols = require(script.Parent.Parent.Symbols)
 local Types = require(script.Parent.Parent.Types)
 type Set<T> = Types.Set<T>
 
@@ -36,8 +37,20 @@ local function ApplyPropertyMapThrows(
                 reconciledConns,
                 instance[key]:Connect(value)
             )
+        elseif typeof(value) == "table" and value._dectype == "Observable" then
+            table.insert(
+                reconciledConns,
+                value:Subscribe(function(newValue)
+                    local valueToApply = if (newValue == Symbols.Nil :: any)
+                        then nil else newValue
+                    instance[key] = valueToApply
+                end)
+            )
+        elseif value == Symbols.Nil then
+            instance[key] = nil
+        else
+            instance[key] = value
         end
-        instance[key] = value
     end
 
     for _, key in deferredKeys do

--- a/src/Reconciler/MountVirtualInstance.luau
+++ b/src/Reconciler/MountVirtualInstance.luau
@@ -1,0 +1,28 @@
+--!strict
+
+local Types = require(script.Parent.Parent.Types)
+
+type VirtualInstance = Types.VirtualInstance
+type ReconciledNode = Types.ReconciledNode
+
+--[[
+    @param rootInstance: Instance - The root Instance to mount the Virtual Instance to.
+    @param childPath: string? - The name of the child to mount. If nil, will use root instance or create "DecRoot" under root instance.
+    @param virtualInstance: Dec.VirtualInstance - The Virtual Instance to mount.
+    @return Dec.ReconciledNode - The Reconciled Node that was mounted.
+
+    Mounts a VirtualInstance to a root instance, and returns the newly created
+    ReconciledNode.
+]]
+local function MountVirtualInstance(
+    rootInstance: Instance,
+    childPath: string?,
+    virtualInstance: VirtualInstance,
+    debugLevel: number
+): ReconciledNode?
+    debugLevel += 1
+    
+    error("Not implemented yet")
+end
+
+return MountVirtualInstance

--- a/src/Reconciler/MountVirtualInstance.luau
+++ b/src/Reconciler/MountVirtualInstance.luau
@@ -19,7 +19,7 @@ local function MountVirtualInstance(
     childPath: string?,
     virtualInstance: VirtualInstance,
     debugLevel: number
-): ReconciledNode?
+): ReconciledNode
     debugLevel += 1
     
     error("Not implemented yet")

--- a/src/Reconciler/RenderVirtualInstance.luau
+++ b/src/Reconciler/RenderVirtualInstance.luau
@@ -1,5 +1,8 @@
 --!strict
 local Types = require(script.Parent.Parent.Types)
+local MountVirtualInstance = require(script.Parent.MountVirtualInstance)
+local UnmountVirtualInstance = require(script.Parent.UnmountVirtualInstance)
+local ReplaceVirtualInstance = require(script.Parent.ReplaceVirtualInstance)
 
 type VirtualInstance = Types.VirtualInstance
 type ReconciledNode = Types.ReconciledNode
@@ -7,19 +10,49 @@ type ReconciledNode = Types.ReconciledNode
 --[[
     @param rootInstance: Instance - The root instance to render to.
     @param virtualInstance: Dec.VirtualInstance? - The virtual instance to render.
-    @param reconciledNode: Dec.ReconciledNode? - The reconciled node to render.
+    @param reconciledNode: Dec.ReconciledNode? - The previous reconciled node to replace
     @return Dec.ReconciledNode - The reconciled node that was rendered.
     
-    Entry point for the Dec reconciler at a top level. This function is called
-    by Root objects (created via Dec.CreateRoot) when they are Rendered with
-    a new VirtualInstance.
+    Entry point for the Dec reconciler on a VirtualInstance. This function is
+    called by Root objects (created via Dec.CreateRoot) when they are Rendered
+    with a new VirtualInstance, and also by observable Children updates. Handles
+    the logic for mounting, unmounting, and replacing VirtualInstances.
 ]]
 local function RenderVirtualInstance(
     rootInstance: Instance,
+    childPath: string?,
     virtualInstance: VirtualInstance?,
-    reconciledNode: ReconciledNode?
+    oldReconciledNode: ReconciledNode?,
+    debugLevel: number
 ): ReconciledNode?
-    error("Not implemented yet")
+    debugLevel += 1
+    
+    if virtualInstance then
+        if oldReconciledNode then
+            return ReplaceVirtualInstance(
+                oldReconciledNode,
+                virtualInstance,
+                debugLevel
+            )
+        else
+            return MountVirtualInstance(
+                rootInstance,
+                childPath,
+                virtualInstance,
+                debugLevel
+            )
+        end
+    else
+        if oldReconciledNode then
+            return UnmountVirtualInstance(
+                oldReconciledNode,
+                debugLevel
+            )
+        else
+            -- Redundant case, nothing to do
+            return nil
+        end
+    end
 end
 
 return RenderVirtualInstance

--- a/src/Reconciler/RenderVirtualInstance.luau
+++ b/src/Reconciler/RenderVirtualInstance.luau
@@ -28,6 +28,11 @@ local function RenderVirtualInstance(
     debugLevel += 1
     
     if virtualInstance then
+        -- Freeze all VirtualInstances on reconciliation
+        if not table.isfrozen(virtualInstance :: any) then
+            table.freeze(virtualInstance)
+        end
+
         if oldReconciledNode then
             return ReplaceVirtualInstance(
                 oldReconciledNode,

--- a/src/Reconciler/RenderVirtualInstance.luau
+++ b/src/Reconciler/RenderVirtualInstance.luau
@@ -1,0 +1,25 @@
+--!strict
+local Types = require(script.Parent.Parent.Types)
+
+type VirtualInstance = Types.VirtualInstance
+type ReconciledNode = Types.ReconciledNode
+
+--[[
+    @param rootInstance: Instance - The root instance to render to.
+    @param virtualInstance: Dec.VirtualInstance? - The virtual instance to render.
+    @param reconciledNode: Dec.ReconciledNode? - The reconciled node to render.
+    @return Dec.ReconciledNode - The reconciled node that was rendered.
+    
+    Entry point for the Dec reconciler at a top level. This function is called
+    by Root objects (created via Dec.CreateRoot) when they are Rendered with
+    a new VirtualInstance.
+]]
+local function RenderVirtualInstance(
+    rootInstance: Instance,
+    virtualInstance: VirtualInstance?,
+    reconciledNode: ReconciledNode?
+): ReconciledNode?
+    error("Not implemented yet")
+end
+
+return RenderVirtualInstance

--- a/src/Reconciler/ReplaceVirtualInstance.luau
+++ b/src/Reconciler/ReplaceVirtualInstance.luau
@@ -23,7 +23,7 @@ local function ReplaceVirtualInstance(
     debugLevel += 1
     
     -- This is a naive implementation. In the future, we may want to support
-    -- object pooling natively via Dec's reconciler.
+    -- object pooling natively via Dec's reconciler?
     UnmountVirtualInstance(oldNode, debugLevel)
     return MountVirtualInstance(
         oldNode._rootInstance,

--- a/src/Reconciler/ReplaceVirtualInstance.luau
+++ b/src/Reconciler/ReplaceVirtualInstance.luau
@@ -1,0 +1,26 @@
+--!strict
+
+local Types = require(script.Parent.Parent.Types)
+
+type VirtualInstance = Types.VirtualInstance
+type ReconciledNode = Types.ReconciledNode
+
+--[[
+    @param oldNode: Dec.ReconciledNode - The old node to replace.
+    @param virtualInstance: Dec.VirtualInstance - The Virtual Instance to replace the old node with.
+    @return Dec.ReconciledNode? - The new Reconciled Node, if the old node was replaced.
+
+    Replaces a reconciled VirtualInstance with a new VirtualInstance, and
+    returns the updated ReconciledNode.
+]]
+local function ReplaceVirtualInstance(
+    oldNode: ReconciledNode,
+    virtualInstance: VirtualInstance,
+    debugLevel: number
+): ReconciledNode?
+    debugLevel += 1
+    
+    error("Not implemented yet")
+end
+
+return ReplaceVirtualInstance

--- a/src/Reconciler/ReplaceVirtualInstance.luau
+++ b/src/Reconciler/ReplaceVirtualInstance.luau
@@ -1,6 +1,8 @@
 --!strict
 
 local Types = require(script.Parent.Parent.Types)
+local UnmountVirtualInstance = require(script.Parent.UnmountVirtualInstance)
+local MountVirtualInstance = require(script.Parent.MountVirtualInstance)
 
 type VirtualInstance = Types.VirtualInstance
 type ReconciledNode = Types.ReconciledNode
@@ -17,10 +19,18 @@ local function ReplaceVirtualInstance(
     oldNode: ReconciledNode,
     virtualInstance: VirtualInstance,
     debugLevel: number
-): ReconciledNode?
+): ReconciledNode
     debugLevel += 1
     
-    error("Not implemented yet")
+    -- This is a naive implementation. In the future, we may want to support
+    -- object pooling natively via Dec's reconciler.
+    UnmountVirtualInstance(oldNode, debugLevel)
+    return MountVirtualInstance(
+        oldNode._rootInstance,
+        oldNode._childPath,
+        virtualInstance,
+        debugLevel
+    )
 end
 
 return ReplaceVirtualInstance

--- a/src/Reconciler/Root.luau
+++ b/src/Reconciler/Root.luau
@@ -1,6 +1,7 @@
 --!strict
 
-local Types = require(script.Parent.Types)
+local Types = require(script.Parent.Parent.Types)
+local RenderVirtualInstance = require(script.Parent.RenderVirtualInstance)
 
 type Root = Types.Root
 type VirtualInstance = Types.VirtualInstance
@@ -26,7 +27,12 @@ function Root.__index.Render(
     self: Root,
     node: VirtualInstance
 ): ReconciledNode
-    error("Not implemented yet")
+    self._reconciled = RenderVirtualInstance(
+        self._instance,
+        node,
+        self._reconciled
+    )
+    return self._reconciled :: ReconciledNode
 end
 
 --[[
@@ -36,7 +42,10 @@ end
     the DataModel but not destroyed.
 ]]
 function Root.__index.Unmount(self: Root)
-    error("Not implemented yet")
+    if self._reconciled then
+        RenderVirtualInstance(self._instance, nil, self._reconciled)
+        self._reconciled = nil
+    end
 end
 
 --[[
@@ -47,7 +56,7 @@ end
     is properly freed.
 ]]
 function Root.__index.Destroy(self: Root)
-    error("Not implemented yet")
+    self:Unmount()
 end
 
 --[[

--- a/src/Reconciler/Root.luau
+++ b/src/Reconciler/Root.luau
@@ -2,6 +2,7 @@
 
 local Types = require(script.Parent.Parent.Types)
 local RenderVirtualInstance = require(script.Parent.RenderVirtualInstance)
+local UnmountVirtualInstance = require(script.Parent.UnmountVirtualInstance)
 
 type Root = Types.Root
 type VirtualInstance = Types.VirtualInstance
@@ -29,8 +30,10 @@ function Root.__index.Render(
 ): ReconciledNode
     self._reconciled = RenderVirtualInstance(
         self._instance,
+        nil,
         node,
-        self._reconciled
+        self._reconciled,
+        1
     )
     return self._reconciled :: ReconciledNode
 end
@@ -43,7 +46,10 @@ end
 ]]
 function Root.__index.Unmount(self: Root)
     if self._reconciled then
-        RenderVirtualInstance(self._instance, nil, self._reconciled)
+        UnmountVirtualInstance(
+            self._reconciled,
+            1
+        )
         self._reconciled = nil
     end
 end

--- a/src/Reconciler/UnmountVirtualInstance.luau
+++ b/src/Reconciler/UnmountVirtualInstance.luau
@@ -1,0 +1,25 @@
+--!strict
+
+local Types = require(script.Parent.Parent.Types)
+
+type VirtualInstance = Types.VirtualInstance
+type ReconciledNode = Types.ReconciledNode
+
+--[[
+    @param node: Dec.ReconciledNode - The node to unmount.
+    @param debugLevel: number - The current debug level.
+    @return Dec.ReconciledNode? - The new Reconciled Node, if the old node was replaced.
+
+    Unmounts a reconciled VirtualInstance, cleaning up all of its children,
+    connections, created instances, etc.
+]]
+local function UnmountVirtualInstance(
+    node: ReconciledNode,
+    debugLevel: number
+)
+    debugLevel += 1
+    
+    error("Not implemented yet")
+end
+
+return UnmountVirtualInstance

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -152,7 +152,7 @@ export type VirtualInstance = typeof(setmetatable(
 		) -> (),
 		Child: (
 			self: VirtualInstance,
-			path: CanBeObservable<string | {string}>,
+			path: string | {string},
 			child: CanBeObservable<Instance | VirtualInstance | nil>
 		) -> (),
 		OnMount: (

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -96,15 +96,30 @@ export type TweenState = Observable<{
 		SetOnCompleted: (self: TweenState, cb: (() -> ())?) -> (),
 	}}
 ))
+export type ChildPath = string | number | {string | number}
 export type ChildMap = CanBeObservable<{
-	[string | {string} | number]: CanBeObservable<
+	[ChildPath]: CanBeObservable<
 		Instance | VirtualInstance | nil
 	>
 }>
+export type VirtualInstanceTrace = {
+	method: string,
+	source: string?,
+	traceback: {{
+		identifier: string,
+		line: number,
+	}}
+}
 export type VirtualInstance = typeof(setmetatable(
 	{} :: {
 		_current: Instance?,
-		_directives: {any},
+		_constructorType: string,
+		_constructorTypeArgument: any,
+		_directives: {{
+			_type: string,
+			_payload: any,
+			_trace: VirtualInstanceTrace?,
+		}},
 	},
 	{} :: {__index: {
 		_dectype: string,
@@ -151,7 +166,7 @@ export type VirtualInstance = typeof(setmetatable(
 		) -> (),
 		Child: (
 			self: VirtualInstance,
-			path: string | {string},
+			path: ChildPath,
 			child: CanBeObservable<Instance | VirtualInstance | nil>
 		) -> (),
 		OnMount: (
@@ -198,14 +213,5 @@ export type Root = typeof(setmetatable(
 		Destroy: (self: Root) -> (),
 	}}
 ))
-
-export type VirtualInstanceTrace = {
-	method: string,
-	source: string?,
-	traceback: {{
-		identifier: string,
-		line: number,
-	}}
-}
 
 return nil

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -6,9 +6,8 @@ export type Unsubscribe = () -> ()
 export type Set<T = any> = {[T]: true}
 export type Observable<T = any> = typeof(setmetatable(
 	{} :: {
-		_consumers: Set<any>?,
-		_consumersWeak: Set<any>?,
 		_current: T,
+        _observerCount: number,
 	},
 	{} :: {__index: {
 		_dectype: string,
@@ -170,6 +169,8 @@ export type ReconciledNode = typeof(setmetatable(
 		_connections: {RBXScriptConnection},
 		_instances: {Instance},
 		_instance: Instance,
+		_rootInstance: Instance,
+		_childPath: string?,
 	},
 	{} :: {__index: {
 		_dectype: string,

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -198,4 +198,13 @@ export type Root = typeof(setmetatable(
 	}}
 ))
 
+export type VirtualInstanceTrace = {
+	method: string,
+	source: string?,
+	traceback: {{
+		identifier: string,
+		line: number,
+	}}
+}
+
 return nil

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -111,7 +111,7 @@ export type VirtualInstance = typeof(setmetatable(
 		_dectype: string,
 		Properties: (
 			self: VirtualInstance,
-			propertyMap: CanBeObservable<{[string]: any}>
+			propertyMap: {[string]: CanBeObservable<any>}
 		) -> (),
 		Tweens: (
 			self: VirtualInstance,
@@ -119,7 +119,7 @@ export type VirtualInstance = typeof(setmetatable(
 		) -> (),
 		Attributes: (
 			self: VirtualInstance,
-			attributeMap: CanBeObservable<{[string]: any}>
+			attributeMap: {[string]: CanBeObservable<any>}
 		) -> (),
 		Tags: (
 			self: VirtualInstance,

--- a/src/VirtualInstance.luau
+++ b/src/VirtualInstance.luau
@@ -8,10 +8,19 @@ type Observable<T> = Types.Observable<T>
 type CanBeObservable<T> = Types.CanBeObservable<T>
 type TweenState = Types.TweenState
 type State<T> = Types.State<T>
+type ChildPath = Types.ChildPath
+type ChildMap = Types.ChildMap
 
+local VIRTUAL_INSTANCE_TRACING = true
 local DEBUG_MAX_TRACEBACK_LENGTH = 3
 
 local function getTrace(methodName: string, traceLevel: number): VirtualInstanceTrace?
+    if not VIRTUAL_INSTANCE_TRACING then
+        return nil
+    end
+
+    traceLevel += 1
+
     local source: string? = debug.info(traceLevel, "s")
     local traceback: {{
         identifier: string,
@@ -41,6 +50,34 @@ local function getTrace(methodName: string, traceLevel: number): VirtualInstance
     }
     return trace
 end
+local function assertNotYetMounted(virtualInstance: VirtualInstance)
+    if table.isfrozen(virtualInstance :: any) then
+        error(
+            "Cannoy modify a VirtualInstance after it has been mounted. " .. 
+            "Please verify your code to make sure you are only defining " ..
+            "properties, attributes, tags, etc. before mounting the " .. 
+            "VirtualInstance (See Dec docs).",
+            2
+        )
+    end
+end
+local function parsePath(path: ChildPath): {string}
+    if typeof(path) == "table" then
+        local parsed = table.create(#path)
+        for _, pathKey in path do
+            if typeof(pathKey) == "string" then
+                table.insert(parsed, pathKey)
+            else
+                table.insert(parsed, tostring(pathKey))
+            end
+        end
+        return parsed
+    elseif typeof(path) == "number" then
+        return {tostring(path)}
+    else
+        return {path}
+    end
+end
 
 local VirtualInstance = {}
 VirtualInstance.__index = {}
@@ -59,7 +96,12 @@ function VirtualInstance.__index.Properties(
     self: VirtualInstance,
     propertyMap: {[string]: CanBeObservable<any>}
 ): ()
-    error("Not implemented yet")
+    assertNotYetMounted(self)
+    table.insert(self._directives, {
+        _type = "Properties",
+        _payload = propertyMap,
+        _trace = getTrace("Dec.Properties", 1),
+    })
 end
 
 --[[
@@ -75,9 +117,20 @@ end
 ]]
 function VirtualInstance.__index.Tweens(
     self: VirtualInstance,
-    TweenState: TweenState | {TweenState}
+    tweenStates: TweenState | {TweenState}
 ): ()
-    error("Not implemented yet")
+    assertNotYetMounted(self)
+    local tweenList: {TweenState}
+    if (tweenStates :: any)._dectype then
+        tweenList = {tweenStates :: any}
+    else
+        tweenList = tweenStates :: any
+    end
+    table.insert(self._directives, {
+        _type = "Tweens",
+        _payload = tweenList,
+        _trace = getTrace("Dec.Tweens", 1),
+    })
 end
 
 --[[
@@ -93,7 +146,12 @@ function VirtualInstance.__index.Attributes(
     self: VirtualInstance,
     attributeMap: {[string]: CanBeObservable<any>}
 ): ()
-    error("Not implemented yet")
+    assertNotYetMounted(self)
+    table.insert(self._directives, {
+        _type = "Tweens",
+        _payload = attributeMap,
+        _trace = getTrace("Dec.Attributes", 1),
+    })
 end
 
 --[[
@@ -108,12 +166,17 @@ function VirtualInstance.__index.Tags(
     self: VirtualInstance,
     tags: CanBeObservable<{string}>
 ): ()
-    error("Not implemented yet")
+    assertNotYetMounted(self)
+    table.insert(self._directives, {
+        _type = "Tags",
+        _payload = tags,
+        _trace = getTrace("Dec.Tags", 1),
+    })
 end
 
 --[[
     @param eventName: string - The name of the event to connect.
-    @param signal: (...any) -> () - The function to be called when the event is fired.
+    @param listener: (...any) -> () - The function to be called when the event is fired.
     @return void
 
     Adds an event listener to the Virtual Instance, which will automatically
@@ -122,9 +185,17 @@ end
 function VirtualInstance.__index.Connect(
     self: VirtualInstance,
     eventName: string,
-    signal: (...any) -> ()
+    listener: (...any) -> ()
 ): ()
-    error("Not implemented yet")
+    assertNotYetMounted(self)
+    table.insert(self._directives, {
+        _type = "Connect",
+        _payload = {
+            event = eventName,
+            listener = listener,
+        },
+        _trace = getTrace("Dec.Connect", 1),
+    })
 end
 
 --[[
@@ -139,7 +210,15 @@ function VirtualInstance.__index.OutProperty(
     propertyName: string,
     outState: State<any>
 ): ()
-    error("Not implemented yet")
+    assertNotYetMounted(self)
+    table.insert(self._directives, {
+        _type = "OutProperty",
+        _payload = {
+            property = propertyName,
+            state = outState,
+        },
+        _trace = getTrace("Dec.OutProperty", 1),
+    })
 end
 
 --[[
@@ -154,7 +233,15 @@ function VirtualInstance.__index.OutAttribute(
     propertyName: string,
     outState: State<any>
 ): ()
-    error("Not implemented yet")
+    assertNotYetMounted(self)
+    table.insert(self._directives, {
+        _type = "OutAttribute",
+        _payload = {
+            attribute = propertyName,
+            state = outState,
+        },
+        _trace = getTrace("Dec.OutAttribute", 1),
+    })
 end
 
 --[[
@@ -167,7 +254,12 @@ function VirtualInstance.__index.OutInstance(
     self: VirtualInstance,
     outState: State<Instance> | State<Instance?>
 ): ()
-    error("Not implemented yet")
+    assertNotYetMounted(self)
+    table.insert(self._directives, {
+        _type = "OutInstance",
+        _payload = outState,
+        _trace = getTrace("Dec.OutInstance", 1),
+    })
 end
 
 --[[
@@ -178,7 +270,12 @@ end
 function VirtualInstance.__index.Copy(
     self: VirtualInstance
 ): VirtualInstance
-    error("Not implemented yet")
+    assertNotYetMounted(self)
+    return setmetatable({
+        _directives = table.clone(self._directives),
+        _constructorType = self._constructorType,
+        _constructorTypeArgument = self._constructorTypeArgument,
+    }, VirtualInstance)
 end
 
 --[[
@@ -189,11 +286,26 @@ end
 function VirtualInstance.__index.DeepCopy(
     self: VirtualInstance
 ): VirtualInstance
-    error("Not implemented yet")
+    assertNotYetMounted(self)
+    local copy = self:Copy()
+    for _, directive in copy._directives do
+        if directive._type == "Child" then
+            if directive._payload._dectype == "VirtualInstance" then
+                directive._payload.child = directive._payload.child:DeepCopy()
+            end
+        elseif directive._type == "Children" then
+            for _, child in directive._payload do
+                if child._dectype == "VirtualInstance" then
+                    child = child:DeepCopy()
+                end
+            end
+        end
+    end
+    return copy
 end
 
 --[[
-    @param path: string | {string}? - The path of the child to add. Can be a dot-separated string or a table of raw names.
+    @param path: Dec.ChildPath - The path of the child to add. Can be a dot-separated string, a table of raw names, or a number.
     @param child: CanBeObservable<Instance | VirtualInstance?> - The child VirtualInstance or actual Instance to add.
     @return void
 
@@ -210,15 +322,23 @@ end
 ]]
 function VirtualInstance.__index.Child(
     self: VirtualInstance,
-    path: string | {string},
+    path: ChildPath,
     child: CanBeObservable<Instance | VirtualInstance | nil>
 ): ()
-    error("Not implemented yet")
+    assertNotYetMounted(self)
+    table.insert(self._directives, {
+        _type = "Child",
+        _payload = {
+            path = parsePath(path),
+            child = child,
+        },
+        _trace = getTrace("Dec.Chlid", 1),
+    })
 end
 
 
 --[[
-    @param childMap: CanBeObservable<{[string | {string} | number]: CanBeObservable<Instance | VirtualInstance?>}>
+    @param childMap: CanBeObservable<{[Dec.ChildPath]: CanBeObservable<Instance | VirtualInstance?>}>
     @return void
 
     Adds multiple children to the VirtualInstance given a child map. See
@@ -227,12 +347,17 @@ end
 function VirtualInstance.__index.Children(
     self: VirtualInstance,
     childMap: CanBeObservable<{
-        [string | {string} | number]: CanBeObservable<
+        [ChildPath]: CanBeObservable<
             Instance | VirtualInstance | nil
         >
     }>
 ): ()
-    error("Not implemented yet")
+    assertNotYetMounted(self)
+    table.insert(self._directives, {
+        _type = "Children",
+        _payload = childMap,
+        _trace = getTrace("Dec.Children", 1),
+    })
 end
 
 --[[
@@ -245,7 +370,12 @@ function VirtualInstance.__index.OnMount(
     self: VirtualInstance,
     callback: (instance: Instance) -> ()
 ): ()
-    error("Not implemented yet")
+    assertNotYetMounted(self)
+    table.insert(self._directives, {
+        _type = "OnMount",
+        _payload = callback,
+        _trace = getTrace("Dec.OnMount", 1),
+    })
 end
 
 --[[
@@ -259,7 +389,12 @@ function VirtualInstance.__index.OnUnmount(
     self: VirtualInstance,
     callback: (instance: Instance) -> ()
 ): ()
-    error("Not implemented yet")
+    assertNotYetMounted(self)
+    table.insert(self._directives, {
+        _type = "OnUnmount",
+        _payload = callback,
+        _trace = getTrace("Dec.OnUnmount", 1),
+    })
 end
 
 --[[
@@ -272,14 +407,42 @@ end
     been reconciled.
 ]]
 function VirtualInstance.new(
+    constructorType: "New" | "Clone" | "Premade",
+    constructorPayload: Instance | string?,
+    defaultProperties: {[string]: CanBeObservable<any>}?,
+    defaultChildMap: {[string | {string} | number]: CanBeObservable<Instance | VirtualInstance?>}?,
     debugMethodName: string,
     debugTraceLevel: number
 ): VirtualInstance
     debugTraceLevel += 1
+
+    local directives = {}
+    if defaultProperties then
+        table.insert(
+            directives,
+            {
+                _type = "Properties",
+                _payload = defaultProperties :: any,
+                _trace = getTrace(debugMethodName, debugTraceLevel)
+            }
+        )
+    end
+    if defaultChildMap then
+        table.insert(
+            directives,
+            {
+                _type = "Children",
+                _payload = defaultChildMap,
+                _trace = if #directives > 0
+                    then directives[1]._trace
+                    else getTrace(debugMethodName, debugTraceLevel)
+            }
+        )
+    end
     return setmetatable({
-        _current = nil,
-        _directives = {},
-        _trace = getTrace(debugMethodName, debugTraceLevel)
+        _directives = directives,
+        _constructorType = constructorType :: string,
+        _constructorTypePayload = constructorPayload :: any
     }, VirtualInstance)
 end
 

--- a/src/VirtualInstance.luau
+++ b/src/VirtualInstance.luau
@@ -346,11 +346,7 @@ end
 ]]
 function VirtualInstance.__index.Children(
     self: VirtualInstance,
-    childMap: CanBeObservable<{
-        [ChildPath]: CanBeObservable<
-            Instance | VirtualInstance | nil
-        >
-    }>
+    childMap: ChildMap
 ): ()
     assertNotYetMounted(self)
     table.insert(self._directives, {
@@ -410,11 +406,10 @@ function VirtualInstance.new(
     constructorType: "New" | "Clone" | "Premade",
     constructorPayload: Instance | string?,
     defaultProperties: {[string]: CanBeObservable<any>}?,
-    defaultChildMap: {[string | {string} | number]: CanBeObservable<Instance | VirtualInstance?>}?,
-    debugMethodName: string,
-    debugTraceLevel: number
+    defaultChildMap: ChildMap?,
+    debugTraceLevel: number?
 ): VirtualInstance
-    debugTraceLevel += 1
+    local traceLevel = (debugTraceLevel or 0) + 1
 
     local directives = {}
     if defaultProperties then
@@ -423,7 +418,7 @@ function VirtualInstance.new(
             {
                 _type = "Properties",
                 _payload = defaultProperties :: any,
-                _trace = getTrace(debugMethodName, debugTraceLevel)
+                _trace = getTrace("Dec." .. constructorType, traceLevel)
             }
         )
     end
@@ -435,7 +430,7 @@ function VirtualInstance.new(
                 _payload = defaultChildMap,
                 _trace = if #directives > 0
                     then directives[1]._trace
-                    else getTrace(debugMethodName, debugTraceLevel)
+                    else getTrace("Dec." .. constructorType, traceLevel)
             }
         )
     end

--- a/src/VirtualInstance.luau
+++ b/src/VirtualInstance.luau
@@ -17,7 +17,7 @@ VirtualInstance.__index = {}
 VirtualInstance.__index._dectype = "VirtualInstance"
 
 --[[
-    @param propertyMap: CanBeObservable<{[string]: any}> - Property map to render
+    @param propertyMap: {[string]: CanBeObservable<any>} - Property map to render
     @return void
 
     Adds properties to be rendered on the instance when it is reconciled.
@@ -27,13 +27,13 @@ VirtualInstance.__index._dectype = "VirtualInstance"
 ]]
 function VirtualInstance.__index.Properties(
     self: VirtualInstance,
-    propertyMap: CanBeObservable<{[string]: CanBeObservable<any>}>
+    propertyMap: {[string]: CanBeObservable<any>}
 ): ()
     error("Not implemented yet")
 end
 
 --[[
-    @param TweenState: CanBeObservable<TweenState | {TweenState}> - TweenState or TweenState list to render
+    @param TweenState: TweenState | {TweenState} - TweenState or TweenState list to render
     @return void
 
     Adds Dec.TweenState objects to play on the Virtual Instance. Multiple calls
@@ -45,13 +45,13 @@ end
 ]]
 function VirtualInstance.__index.Tweens(
     self: VirtualInstance,
-    TweenState: CanBeObservable<TweenState | {TweenState}>
+    TweenState: TweenState | {TweenState}
 ): ()
     error("Not implemented yet")
 end
 
 --[[
-    @param attributeMap: CanBeObservable<{[string]: any}> - Attribute map to render
+    @param attributeMap: {[string]: any} - Attribute map to render
     @return void
 
     Adds attributes to be rendered on the instance when it is reconciled.
@@ -61,7 +61,7 @@ end
 ]]
 function VirtualInstance.__index.Attributes(
     self: VirtualInstance,
-    attributeMap: CanBeObservable<{[string]: CanBeObservable<any>}>
+    attributeMap: {[string]: CanBeObservable<any>}
 ): ()
     error("Not implemented yet")
 end
@@ -163,7 +163,7 @@ function VirtualInstance.__index.DeepCopy(
 end
 
 --[[
-    @param path: CanBeObservable<string | {string}?> - The path of the child to add.
+    @param path: string | {string}? - The path of the child to add. Can be a dot-separated string or a table of raw names.
     @param child: CanBeObservable<Instance | VirtualInstance?> - The child VirtualInstance or actual Instance to add.
     @return void
 
@@ -180,7 +180,7 @@ end
 ]]
 function VirtualInstance.__index.Child(
     self: VirtualInstance,
-    path: CanBeObservable<string | {string}>,
+    path: string | {string},
     child: CanBeObservable<Instance | VirtualInstance | nil>
 ): ()
     error("Not implemented yet")

--- a/src/VirtualInstance.luau
+++ b/src/VirtualInstance.luau
@@ -9,8 +9,38 @@ type CanBeObservable<T> = Types.CanBeObservable<T>
 type TweenState = Types.TweenState
 type State<T> = Types.State<T>
 
-local DEBUG_TRACE_START_LEVEL = 3
 local DEBUG_MAX_TRACEBACK_LENGTH = 3
+
+local function getTrace(methodName: string, traceLevel: number): VirtualInstanceTrace?
+    local source: string? = debug.info(traceLevel, "s")
+    local traceback: {{
+        identifier: string,
+        line: number
+    }} = {}
+    if source then
+        for i = 0, DEBUG_MAX_TRACEBACK_LENGTH - 1 do
+            local traceLevelAtIndex = traceLevel + i
+            if debug.info(traceLevelAtIndex, "s") ~= source then
+                break
+            end
+            local ident = debug.info(traceLevelAtIndex, "n")
+            local line = debug.info(traceLevelAtIndex, "l")
+            if not ident or not line then
+                break
+            end
+            table.insert(traceback, {
+                identifier = ident,
+                line = line,
+            })
+        end
+    end
+    local trace: VirtualInstanceTrace? = {
+        method = methodName,
+        source = source,
+        traceback = traceback,
+    }
+    return trace
+end
 
 local VirtualInstance = {}
 VirtualInstance.__index = {}
@@ -241,37 +271,15 @@ end
     reconciled. Use Observers instead to mutate a VirtualInstance after it has
     been reconciled.
 ]]
-function VirtualInstance.new(method: string): VirtualInstance
-    local source: string? = debug.info(DEBUG_TRACE_START_LEVEL, "s")
-    local traceback: {{
-        identifier: string,
-        line: number
-    }} = {}
-    if source then
-        for i = 1, DEBUG_MAX_TRACEBACK_LENGTH do
-            if debug.info(DEBUG_TRACE_START_LEVEL + i, "s") ~= source then
-                break
-            end
-            local ident = debug.info(DEBUG_TRACE_START_LEVEL + i, "n")
-            local line = debug.info(DEBUG_TRACE_START_LEVEL + i, "l")
-            if not ident or not line then
-                break
-            end
-            table.insert(traceback, {
-                identifier = ident,
-                line = line,
-            })
-        end
-    end
-    local trace: VirtualInstanceTrace? = {
-        method = method,
-        source = source,
-        traceback = traceback,
-    }
+function VirtualInstance.new(
+    debugMethodName: string,
+    debugTraceLevel: number
+): VirtualInstance
+    debugTraceLevel += 1
     return setmetatable({
         _current = nil,
         _directives = {},
-        _trace = trace
+        _trace = getTrace(debugMethodName, debugTraceLevel)
     }, VirtualInstance)
 end
 

--- a/src/VirtualInstance.luau
+++ b/src/VirtualInstance.luau
@@ -2,11 +2,15 @@
 
 local Types = require(script.Parent.Types)
 
-export type VirtualInstance = Types.VirtualInstance
-export type Observable<T> = Types.Observable<T>
-export type CanBeObservable<T> = Types.CanBeObservable<T>
-export type TweenState = Types.TweenState
-export type State<T> = Types.State<T>
+type VirtualInstanceTrace = Types.VirtualInstanceTrace
+type VirtualInstance = Types.VirtualInstance
+type Observable<T> = Types.Observable<T>
+type CanBeObservable<T> = Types.CanBeObservable<T>
+type TweenState = Types.TweenState
+type State<T> = Types.State<T>
+
+local DEBUG_TRACE_START_LEVEL = 3
+local DEBUG_MAX_TRACEBACK_LENGTH = 3
 
 local VirtualInstance = {}
 VirtualInstance.__index = {}
@@ -237,10 +241,37 @@ end
     reconciled. Use Observers instead to mutate a VirtualInstance after it has
     been reconciled.
 ]]
-function VirtualInstance.new(): VirtualInstance
+function VirtualInstance.new(method: string): VirtualInstance
+    local source: string? = debug.info(DEBUG_TRACE_START_LEVEL, "s")
+    local traceback: {{
+        identifier: string,
+        line: number
+    }} = {}
+    if source then
+        for i = 1, DEBUG_MAX_TRACEBACK_LENGTH do
+            if debug.info(DEBUG_TRACE_START_LEVEL + i, "s") ~= source then
+                break
+            end
+            local ident = debug.info(DEBUG_TRACE_START_LEVEL + i, "n")
+            local line = debug.info(DEBUG_TRACE_START_LEVEL + i, "l")
+            if not ident or not line then
+                break
+            end
+            table.insert(traceback, {
+                identifier = ident,
+                line = line,
+            })
+        end
+    end
+    local trace: VirtualInstanceTrace? = {
+        method = method,
+        source = source,
+        traceback = traceback,
+    }
     return setmetatable({
         _current = nil,
         _directives = {},
+        _trace = trace
     }, VirtualInstance)
 end
 

--- a/src/VirtualInstanceCreators.luau
+++ b/src/VirtualInstanceCreators.luau
@@ -19,7 +19,13 @@ function VirtualInstanceCreators.New(
     props: {[string]: any}?,
     children: Types.ChildMap?
 ): Types.VirtualInstance
-    error("Not implemented yet")
+    return VirtualInstance.new(
+        "New",
+        className,
+        props,
+        children,
+        1
+    )
 end
 
 --[[
@@ -36,7 +42,13 @@ function VirtualInstanceCreators.Clone(
     props: {[string]: any}?,
     children: Types.ChildMap?
 ): Types.VirtualInstance
-    error("Not implemented yet")
+    return VirtualInstance.new(
+        "Clone",
+        template,
+        props,
+        children,
+        1
+    )
 end
 
 --[[
@@ -57,7 +69,13 @@ function VirtualInstanceCreators.Premade(
     props: {[string]: any}?,
     children: Types.ChildMap?
 ): Types.VirtualInstance
-    error("Not implemented yet")
+    return VirtualInstance.new(
+        "Premade",
+        nil,
+        props,
+        children,
+        1
+    )
 end
 
 return VirtualInstanceCreators

--- a/src/init.luau
+++ b/src/init.luau
@@ -14,7 +14,7 @@
 local Types = require(script.Types)
 local Symbols = require(script.Symbols)
 local VirtualInstanceCreators = require(script.VirtualInstanceCreators)
-local Root = require(script.Root)
+local Root = require(script.Reconciler.Root)
 
 export type Unsubscribe = Types.Unsubscribe
 export type Observable<T> = Types.Observable<T>


### PR DESCRIPTION
- Initializes a skeleton for the Reconciler
- Implements element tracing for virtual instances and declared mutations
- Implements some methods (Mount/Unmount/Replace) for root level VirtualInstance
- Implementation for reconciling Dec.Properties(), supporting observables.
- Initial implementation of all VirtualInstance/VirtualInstanceCreators methods!