### PR TITLE
Improve Premade Templating Utils

### DIFF
--- a/src/Reconciler/ApplyChildDirectives.luau
+++ b/src/Reconciler/ApplyChildDirectives.luau
@@ -99,7 +99,7 @@ local function ApplyChildrenDirective(
             local chainedVirtualInstance: any = virtualInstance
             local finalChildKey: string
 
-            -- Flaten list of multiple names to a chain of Premade
+            -- De-Sugar/Flaten list of multiple names to a chain of Premade
             -- VirtualInstances with each nested child as a VirtualInstance.
             local nameList = parsePath(childPath)
             for i = #nameList, 1, -1 do
@@ -111,6 +111,9 @@ local function ApplyChildrenDirective(
                     local parent = VirtualInstanceCreators.Premade()
                     parent:AddChild(name, child)
                     chainedVirtualInstance = parent
+                    for _, parentDirective in parent._directives do
+                        parentDirective._trace = directive._trace
+                    end
                 end
             end
             if not finalChildKey then

--- a/src/Reconciler/CreateOrFindReconciledInstance.luau
+++ b/src/Reconciler/CreateOrFindReconciledInstance.luau
@@ -84,6 +84,92 @@ local function FindChildReconciledInstance(
     }
 end
 
+local function CloneLatentResolvedTemplate(
+    childPath: string?,
+    virtualInstance: VirtualInstance,
+    templateArg: VirtualInstance,
+    debugLevel: number
+): PseudoPromise
+    debugLevel += 1
+    local result: Instance? = nil
+    local onResultCallbacks: {(Instance, debugLevel: number) -> ()} = {}
+    local cancelled = false
+    local stopTrackingLatentResolve: (() -> ())? = nil
+    task.defer(function()
+        if cancelled then
+            return
+        end
+        local templateNode = templateArg._reconciledNode
+        if not templateNode then
+            local firstEncounteredTrace = nil
+            for _, directive in virtualInstance._directives do
+                if directive._trace then
+                    firstEncounteredTrace = directive._trace
+                    break
+                end
+            end
+            if not firstEncounteredTrace then
+                for _, directive in templateArg._directives do
+                    if directive._trace then
+                        firstEncounteredTrace = directive._trace
+                        break
+                    end
+                end
+            end
+            EmitTracedError(
+                "Error when mounting cloned VirtualInstance: The " .. 
+                "provided template must be an Instance, or a " .. 
+                "VirtualInstance that has already been mounted or " .. 
+                "will be mounted within the same frame. Perhaps you " ..
+                "passed an unmounted VirtualInstance as a template " .. 
+                "for Dec.Clone()?",
+                firstEncounteredTrace,
+                1
+            )
+            return
+        end
+
+        local instance = templateNode._instance
+        if instance then
+            local newInstance = instance:Clone()
+            newInstance.Name = childPath
+                or DEFAULT_CREATED_CHILD_NAME
+            result = newInstance
+            for _, cb in onResultCallbacks do
+                task.spawn(cb, newInstance, 1)
+            end
+        else
+            local function onResolve(template: Instance)
+                local newInstance = template:Clone()
+                newInstance.Name = childPath
+                    or DEFAULT_CREATED_CHILD_NAME
+                for _, cb in onResultCallbacks do
+                    task.spawn(cb, newInstance, 1)
+                end
+            end
+            templateNode._instanceResolvedCallbacks[onResolve] = true
+            stopTrackingLatentResolve = function()
+                templateNode._instanceResolvedCallbacks[onResolve] = nil
+            end
+        end
+    end)
+    return {
+        andThen = function(callback)
+            if result then
+                callback(result, debugLevel + 1)
+            else
+                table.insert(onResultCallbacks, callback)
+            end
+        end,
+        cancel = function()
+            cancelled = true
+            if stopTrackingLatentResolve then
+                stopTrackingLatentResolve()
+            end
+        end,
+    }
+end
+
 local function CloneTemplateReconciledInstance(
     childPath: string?,
     virtualInstance: VirtualInstance,
@@ -116,84 +202,8 @@ local function CloneTemplateReconciledInstance(
             -- check if the template VInstance was mounted this frame and wait
             -- for the template at least to resolve. Otherwise, raise an
             -- exception.
-            local result: Instance? = nil
-            local onResultCallbacks: {(Instance, debugLevel: number) -> ()} = {}
-            local cancelled = false
-            local stopTrackingLatentResolve: (() -> ())? = nil
-            task.defer(function()
-                if cancelled then
-                    return
-                end
-                local instance
-                if templateArg._reconciledNode then
-                    instance = templateArg._reconciledNode._instance
-                else
-                    local firstEncounteredTrace = nil
-                    for _, directive in virtualInstance._directives do
-                        if directive._trace then
-                            firstEncounteredTrace = directive._trace
-                            break
-                        end
-                    end
-                    if not firstEncounteredTrace then
-                        for _, directive in templateArg._directives do
-                            if directive._trace then
-                                firstEncounteredTrace = directive._trace
-                                break
-                            end
-                        end
-                    end
-                    EmitTracedError(
-                        "Error when mounting cloned VirtualInstance: The " .. 
-                        "provided template must be an Instance, or a " .. 
-                        "VirtualInstance that has already been mounted or " .. 
-                        "will be mounted within the same frame. Perhaps you " ..
-                        "passed an unmounted VirtualInstance as a template " .. 
-                        "for Dec.Clone()?",
-                        firstEncounteredTrace,
-                        1
-                    )
-                end
-                if instance then
-                    local newInstance = instance:Clone()
-                    newInstance.Name = childPath
-                        or DEFAULT_CREATED_CHILD_NAME
-                    result = newInstance
-                    for _, cb in onResultCallbacks do
-                        task.spawn(cb, newInstance, 1)
-                    end
-                else
-                    local function onResolve(template: Instance)
-                        local newInstance = template:Clone()
-                        newInstance.Name = childPath
-                            or DEFAULT_CREATED_CHILD_NAME
-                        for _, cb in onResultCallbacks do
-                            task.spawn(cb, newInstance, 1)
-                        end
-                    end
-                    templateArg._reconciledNode._instanceResolvedCallbacks
-                        [onResolve] = true
-                    stopTrackingLatentResolve = function()
-                        templateArg._reconciledNode._instanceResolvedCallbacks
-                            [onResolve] = nil
-                    end
-                end
-            end)
-            return {
-                andThen = function(callback)
-                    if result then
-                        callback(result, debugLevel + 1)
-                    else
-                        table.insert(onResultCallbacks, callback)
-                    end
-                end,
-                cancel = function()
-                    cancelled = true
-                    if stopTrackingLatentResolve then
-                        stopTrackingLatentResolve()
-                    end
-                end,
-            }
+            return CloneLatentResolvedTemplate(childPath, virtualInstance,
+                templateArg, debugLevel)
         end
     else
         -- In standard case, use template instance provided

--- a/src/Reconciler/CreateOrFindReconciledInstance.luau
+++ b/src/Reconciler/CreateOrFindReconciledInstance.luau
@@ -1,8 +1,188 @@
 --!strict
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local EmitTracedError = require(script.Parent.EmitTracedError)
+local IsVirtualInstance = require(ReplicatedStorage.Packages.Dec.Reflection.IsVirtualInstance)
 local Types = require(script.Parent.Parent.Types)
 type VirtualInstance = Types.VirtualInstance
 
-local WAIT_FOR_CHILD_TIMEOUT = 15
+local WAIT_FOR_CHILD_TIMEOUT = 30
+local DEFAULT_CREATED_CHILD_NAME = "DecRoot"
+
+type PseudoPromise = {
+    andThen: (callback: (Instance, number) -> ()) -> (),
+    cancel: () -> (),
+}
+
+local function CreateNewReconciledInstance(
+    childPath: string?,
+    virtualInstance: VirtualInstance,
+    debugLevel: number
+): PseudoPromise
+    debugLevel += 1
+    local newInstance = Instance.new(virtualInstance._constructorTypeArgument)
+    newInstance.Name = childPath or DEFAULT_CREATED_CHILD_NAME
+    return {
+        andThen = function(callback)
+            callback(newInstance, debugLevel + 1)
+        end,
+        cancel = function() end,
+    }
+end
+
+local function FindChildReconciledInstance(
+    hostInstance: Instance,
+    childPath: string?,
+    debugLevel: number
+): PseudoPromise
+    debugLevel += 1
+    local result: Instance? = nil
+    local onResultCallbacks: {(Instance, debugLevel: number) -> ()} = {}
+    local childAddedConn: RBXScriptConnection? = nil
+    local cancelled = false
+    if childPath then
+        local initialChild = hostInstance:FindFirstChild(childPath)
+        if initialChild then
+            result = initialChild
+        else
+            childAddedConn = hostInstance.ChildAdded:Connect(function(child)
+                if child.Name == childPath then
+                    result = child
+                    for _, cb in onResultCallbacks do
+                        task.spawn(cb, child, debugLevel + 1)
+                    end
+                end
+            end)
+            task.delay(WAIT_FOR_CHILD_TIMEOUT, function()
+                if cancelled then
+                    return
+                end
+                warn(
+                    "Timeout when attempting to mount premade " .. 
+                    "VirtualInstance under " .. hostInstance:GetFullName()
+                    .. ": No child was found named '" .. childPath .. "'"
+                )
+            end)
+        end
+    else
+        result = hostInstance
+    end
+    return {
+        andThen = function(callback)
+            if result then
+                callback(result, debugLevel + 1)
+            else
+                table.insert(onResultCallbacks, callback)
+            end
+        end,
+        cancel = function()
+            cancelled = true
+            if childAddedConn then
+                childAddedConn:Disconnect()
+                childAddedConn = nil
+            end
+        end
+    }
+end
+
+local function CloneTemplateReconciledInstance(
+    childPath: string?,
+    virtualInstance: VirtualInstance,
+    debugLevel: number
+): PseudoPromise
+    debugLevel += 1
+    local templateArg = virtualInstance._constructorTypeArgument
+    if IsVirtualInstance(templateArg) then
+        if templateArg._constructorType == "New" then
+            -- In the case that our template was a "Dec.New" virtual
+            -- instance, simply treat as a Dec.New call
+            return CreateNewReconciledInstance(childPath, templateArg,
+                debugLevel)
+        elseif
+            templateArg._reconciledNode
+            and templateArg._reconciledNode._instance
+        then
+            -- In the case that the template is an already-mounted node,
+            -- immediately clone it.
+            local newInstance = templateArg:Clone()
+            newInstance.Name = childPath or DEFAULT_CREATED_CHILD_NAME
+            return {
+                andThen = function(callback)
+                    callback(newInstance, debugLevel + 1)
+                end,
+                cancel = function() end,
+            }
+        else
+            -- In the case that we passed in a latent-mounted VirtualInstance,
+            -- check if it has resolved into an instance this frame. If not,
+            -- raise an exception.
+            local result: Instance? = nil
+            local onResultCallbacks: {(Instance, debugLevel: number) -> ()} = {}
+            local cancelled = false
+            task.defer(function()
+                if cancelled then
+                    return
+                end
+                local instance
+                if templateArg._reconciledNode then
+                    instance = templateArg._reconciledNode._instance
+                end
+                if not instance then
+                    local firstEncounteredTrace = nil
+                    for _, directive in virtualInstance._directives do
+                        if directive._trace then
+                            firstEncounteredTrace = directive._trace
+                            break
+                        end
+                    end
+                    if not firstEncounteredTrace then
+                        for _, directive in templateArg._directives do
+                            if directive._trace then
+                                firstEncounteredTrace = directive._trace
+                                break
+                            end
+                        end
+                    end
+                    EmitTracedError(
+                        "Error when mounting cloned VirtualInstance: The " .. 
+                        "provided template must be an Instance, or a " .. 
+                        "VirtualInstance that has already been mounted or " .. 
+                        "will be mounted within the same frame. Perhaps you " ..
+                        "passed an unmounted VirtualInstance as a template " .. 
+                        "for Dec.Clone()?",
+                        firstEncounteredTrace,
+                        1
+                    )
+                end
+                result = instance
+                for _, cb in onResultCallbacks do
+                    task.spawn(cb, instance, 1)
+                end
+            end)
+            return {
+                andThen = function(callback)
+                    if result then
+                        callback(result, debugLevel + 1)
+                    else
+                        table.insert(onResultCallbacks, callback)
+                    end
+                end,
+                cancel = function()
+                    cancelled = true
+                end,
+            }
+        end
+    else
+        -- In standard case, use template instance provided
+        local newInstance = templateArg:Clone()
+        newInstance.Name = childPath or DEFAULT_CREATED_CHILD_NAME
+        return {
+            andThen = function(callback)
+                callback(newInstance, debugLevel + 1)
+            end,
+            cancel = function() end,
+        }
+    end
+end
 
 --[[
     @param hostInstance: Instance
@@ -23,65 +203,15 @@ local function CreateOrFindReconciledInstance(
     debugLevel: number
 )
     debugLevel += 1
-    local result: Instance? = nil
-    local onResultCallbacks: {(Instance, debugLevel: number) -> ()} = {}
 
-    local childAddedConn: RBXScriptConnection? = nil
-    local cancelled = false
     if virtualInstance._constructorType == "New" then
-        local newInstance = Instance.new(
-            virtualInstance._constructorTypeArgument)
-        newInstance.Name = childPath or "DecRoot"
-        result = newInstance
+        return CreateNewReconciledInstance(childPath, virtualInstance,
+            debugLevel)
     elseif virtualInstance._constructorType == "Clone" then
-        local newInstance = virtualInstance._constructorTypeArgument:Clone()
-        newInstance.Name = childPath or "DecRoot"
-        result = newInstance
+        return CloneTemplateReconciledInstance(childPath, virtualInstance,
+            debugLevel)
     else
-        if childPath then
-            local initialChild = hostInstance:FindFirstChild(childPath)
-            if initialChild then
-                result = initialChild
-            else
-                childAddedConn = hostInstance.ChildAdded:Connect(function(child)
-                    if child.Name == childPath then
-                        result = child
-                        for _, cb in onResultCallbacks do
-                            task.spawn(cb, child, debugLevel + 1)
-                        end
-                    end
-                end)
-                task.delay(WAIT_FOR_CHILD_TIMEOUT, function()
-                    if cancelled then
-                        return
-                    end
-                    warn(
-                        "Timeout when attempting to mount premade " .. 
-                        "VirtualInstance under " .. hostInstance:GetFullName()
-                        .. ": No child was found named '" .. childPath .. "'"
-                    )
-                end)
-            end
-        else
-            result = hostInstance
-        end
+        return FindChildReconciledInstance(hostInstance, childPath, debugLevel)
     end
-
-    return {
-        andThen = function(callback)
-            if result then
-                callback(result, debugLevel + 1)
-            else
-                table.insert(onResultCallbacks, callback)
-            end
-        end,
-        cancel = function()
-            cancelled = true
-            if childAddedConn then
-                childAddedConn:Disconnect()
-                childAddedConn = nil
-            end
-        end
-    }
 end
 return CreateOrFindReconciledInstance

--- a/src/Reconciler/CreateOrFindReconciledInstance.luau
+++ b/src/Reconciler/CreateOrFindReconciledInstance.luau
@@ -113,11 +113,13 @@ local function CloneTemplateReconciledInstance(
             }
         else
             -- In the case that we passed in a latent-mounted VirtualInstance,
-            -- check if it has resolved into an instance this frame. If not,
-            -- raise an exception.
+            -- check if the template VInstance was mounted this frame and wait
+            -- for the template at least to resolve. Otherwise, raise an
+            -- exception.
             local result: Instance? = nil
             local onResultCallbacks: {(Instance, debugLevel: number) -> ()} = {}
             local cancelled = false
+            local stopTrackingLatentResolve: (() -> ())? = nil
             task.defer(function()
                 if cancelled then
                     return
@@ -125,8 +127,7 @@ local function CloneTemplateReconciledInstance(
                 local instance
                 if templateArg._reconciledNode then
                     instance = templateArg._reconciledNode._instance
-                end
-                if not instance then
+                else
                     local firstEncounteredTrace = nil
                     for _, directive in virtualInstance._directives do
                         if directive._trace then
@@ -153,9 +154,29 @@ local function CloneTemplateReconciledInstance(
                         1
                     )
                 end
-                result = instance
-                for _, cb in onResultCallbacks do
-                    task.spawn(cb, instance, 1)
+                if instance then
+                    local newInstance = instance:Clone()
+                    newInstance.Name = childPath
+                        or DEFAULT_CREATED_CHILD_NAME
+                    result = newInstance
+                    for _, cb in onResultCallbacks do
+                        task.spawn(cb, newInstance, 1)
+                    end
+                else
+                    local function onResolve(template: Instance)
+                        local newInstance = template:Clone()
+                        newInstance.Name = childPath
+                            or DEFAULT_CREATED_CHILD_NAME
+                        for _, cb in onResultCallbacks do
+                            task.spawn(cb, newInstance, 1)
+                        end
+                    end
+                    templateArg._reconciledNode._instanceResolvedCallbacks
+                        [onResolve] = true
+                    stopTrackingLatentResolve = function()
+                        templateArg._reconciledNode._instanceResolvedCallbacks
+                            [onResolve] = nil
+                    end
                 end
             end)
             return {
@@ -168,6 +189,9 @@ local function CloneTemplateReconciledInstance(
                 end,
                 cancel = function()
                     cancelled = true
+                    if stopTrackingLatentResolve then
+                        stopTrackingLatentResolve()
+                    end
                 end,
             }
         end
@@ -201,7 +225,7 @@ local function CreateOrFindReconciledInstance(
     childPath: string?,
     virtualInstance: VirtualInstance,
     debugLevel: number
-)
+): PseudoPromise
     debugLevel += 1
 
     if virtualInstance._constructorType == "New" then

--- a/src/Reconciler/CreateReconciledNode.luau
+++ b/src/Reconciler/CreateReconciledNode.luau
@@ -17,6 +17,7 @@ local function CreateReconciledNode(
     return {
         _dectype = "ReconciledNode",
         _instance = instance,
+        _instanceResolvedCallbacks = {},
         _rootInstance = rootInstance,
         _childPath = childPath,
         _instancesToCleanup = {},

--- a/src/Reconciler/MountVirtualInstance.luau
+++ b/src/Reconciler/MountVirtualInstance.luau
@@ -48,6 +48,9 @@ local function MountVirtualInstance(
         end 
         ApplyBasicDirectives(node, virtualInstance, innerDebugLevel)
         ApplyChildDirectives(node, virtualInstance, innerDebugLevel)
+        for callback in node._instanceResolvedCallbacks do
+            task.spawn(callback, instance)
+        end
     end)
     if not node._instance then
         table.insert(node._unsubscribes, instancePromise.cancel)

--- a/src/Reconciler/MountVirtualInstance.luau
+++ b/src/Reconciler/MountVirtualInstance.luau
@@ -33,6 +33,12 @@ local function MountVirtualInstance(
         rootInstance,
         childPath
     )
+    -- Freeze all VirtualInstances on mount
+    if virtualInstance._reconciledNode then
+        error("VirtualInstance cannot be mounted more than once", debugLevel)
+    end
+    virtualInstance._reconciledNode = node
+    table.freeze(virtualInstance)
     instancePromise.andThen(function(instance, innerDebugLevel)
         innerDebugLevel += 1
         node._instance = instance

--- a/src/Reconciler/RenderVirtualInstance.luau
+++ b/src/Reconciler/RenderVirtualInstance.luau
@@ -28,11 +28,6 @@ local function RenderVirtualInstance(
     debugLevel += 1
     
     if virtualInstance then
-        -- Freeze all VirtualInstances on reconciliation
-        if not table.isfrozen(virtualInstance :: any) then
-            table.freeze(virtualInstance)
-        end
-
         if oldReconciledNode then
             return ReplaceVirtualInstance(
                 oldReconciledNode,

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -217,6 +217,17 @@ export type VirtualInstance = typeof(setmetatable(
             self: VirtualInstance,
             childMap: ChildMap
         ) -> (),
+        FindChild: (
+            self: VirtualInstance,
+            childPath: ChildPath
+        ) -> VirtualInstance,
+        ExtractChildTemplate: ((
+            self: VirtualInstance,
+            childPath: ChildPath
+        ) -> VirtualInstance) & ((
+            self: VirtualInstance,
+            condition: (child: Instance) -> boolean
+        ) -> VirtualInstance),
         AddChild: (
             self: VirtualInstance,
             path: ChildPath,

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -249,6 +249,7 @@ export type ReconciledNode = {
     _unsubscribes: {Unsubscribe},
     _instancesToCleanup: {Instance},
     _instance: Instance?,
+    _instanceResolvedCallbacks: {[(Instance) -> ()]: boolean},
     _rootInstance: Instance,
     _childPath: string?,
     _dectype: string,

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -156,6 +156,7 @@ export type VirtualInstance = typeof(setmetatable(
         _constructorType: string,
         _constructorTypeArgument: any,
         _directives: {VirtualInstanceDirective},
+        _reconciledNode: ReconciledNode?
     },
     {} :: {__index: {
         _dectype: string,

--- a/src/VirtualInstance.luau
+++ b/src/VirtualInstance.luau
@@ -423,6 +423,87 @@ function VirtualInstance.__index.OnUnmount(
 end
 
 --[[
+    @param nameOrPredicate: string | (Instance) -> boolean - The condition for extracting the template
+    @return Dec.VirtualInstance - A new VirtualInstance, cloned from a child of the parent instance
+    Specifies that when the VirtualInstance is mounted, returns a new
+    VirtualInstance which automatically mounts on the first child matching
+    the name (or predicate) defined in the first argument to this method.
+    
+    Upon mount, all other children matching this condition will be destroyed,
+    and the template will be parented to `nil` by defalt. On unmount, it will be
+    reparented to its original location if possible.
+
+    Usage example:
+
+```lua
+local function CardListUI()
+    -- Define a VirtualInstance to be mounted on pre-existing UI in PlayerGui
+    local rootUI = Dec.Premade()
+
+    -- Index a ScrollingFrame containing template cards
+    local cardList = rootUI:FindChild("ScrollingFrame")
+
+    -- Extract the first template named "CardTemplate", and destroy all other
+    -- premade templates with that same name
+    local cardTemplate = cardList:ExtractChildTemplate("CardTemplate")
+
+    -- Generate 10 cards from the template
+    local cards = {}
+    for i = 1, 10 do
+        table.insert(cards, Dec.Clone(cardTemplate, {
+            LayoutOrder = i
+        }))
+    end
+
+    return rootUI
+end
+```
+]]
+function VirtualInstance.__index.ExtractChildTemplate(
+    self: VirtualInstance,
+    nameOrPredicate: string | (instance: Instance) -> ()
+): ()
+    assertNotYetMounted(self)
+    table.insert(self._directives, {
+        _type = "ExtractChildTemplate",
+        _payload = nameOrPredicate,
+        _trace = getTrace("Dec.ExtractChildTemplate", 1),
+    })
+end
+
+--[[
+    @param nameOrPredicate: string | (Instance) -> boolean - The name of the child instance to find (or predicate)
+    @return Dec.VirtualInstance - A new VirtualInstance representing the child of the parent VirtualInstance
+
+    Creates a new VirtualInstance that automatically mounts on the child of the
+    parent VirtualInstance. Will wait until a child with the given name is
+    found, or if a function is provided, will wait until a child is found for
+    which the provided callback returns true.
+
+    The following statements are equivalent:
+```lua
+local child = Dec.Premade()
+local parent = Dec.Premade({}, {ChildName = child})
+```
+
+```lua
+local parent = Dec.Premade()
+local child = parent:FindChild("ChildName")
+```
+]]
+function VirtualInstance.__index.FindChild(
+    self: VirtualInstance,
+    nameOrPredicate: string | (instance: Instance) -> ()
+): ()
+    assertNotYetMounted(self)
+    table.insert(self._directives, {
+        _type = "ExtractChildTemplate",
+        _payload = nameOrPredicate,
+        _trace = getTrace("Dec.ExtractChildTemplate", 1),
+    })
+end
+
+--[[
     @return Dec.VirtualInstance - A new, empty Virtual Instance.
 
     A mutable element that Dec reconciles into a Roblox Instance.

--- a/src/VirtualInstance.luau
+++ b/src/VirtualInstance.luau
@@ -433,7 +433,7 @@ end
 ]]
 function VirtualInstance.new(
     constructorType: "New" | "Clone" | "Premade",
-    constructorPayload: Instance | string?,
+    constructorPayload: any?,
     defaultProperties: {[string]: CanBeObservable<any>}?,
     defaultChildMap: ChildMap?,
     debugTraceLevel: number?

--- a/src/VirtualInstance.luau
+++ b/src/VirtualInstance.luau
@@ -497,9 +497,9 @@ function VirtualInstance.__index.FindChild(
 ): ()
     assertNotYetMounted(self)
     table.insert(self._directives, {
-        _type = "ExtractChildTemplate",
+        _type = "FindChild",
         _payload = nameOrPredicate,
-        _trace = getTrace("Dec.ExtractChildTemplate", 1),
+        _trace = getTrace("Dec.FindChild", 1),
     })
 end
 

--- a/src/VirtualInstance.luau
+++ b/src/VirtualInstance.luau
@@ -423,13 +423,13 @@ function VirtualInstance.__index.OnUnmount(
 end
 
 --[[
-    @param nameOrPredicate: string | (Instance) -> boolean - The condition for extracting the template
+    @param nameOrPredicate: string | {string} - The name of the child to be extracted as a template
     @return Dec.VirtualInstance - A new VirtualInstance, cloned from a child of the parent instance
     Specifies that when the VirtualInstance is mounted, returns a new
     VirtualInstance which automatically mounts on the first child matching
     the name (or predicate) defined in the first argument to this method.
     
-    Upon mount, all other children matching this condition will be destroyed,
+    Upon mount, all other children matching this name will be destroyed,
     and the template will be parented to `nil` by defalt. On unmount, it will be
     reparented to its original location if possible.
 
@@ -461,14 +461,21 @@ end
 ]]
 function VirtualInstance.__index.ExtractChildTemplate(
     self: VirtualInstance,
-    nameOrPredicate: string | (instance: Instance) -> ()
+    childPath: string | {string}
 ): ()
     assertNotYetMounted(self)
-    table.insert(self._directives, {
-        _type = "ExtractChildTemplate",
-        _payload = nameOrPredicate,
-        _trace = getTrace("Dec.ExtractChildTemplate", 1),
-    })
+    local childVInst = self:FindChild(childPath)
+    local templateParent = nil
+    childVInst:OnMount(function(instance)
+        templateParent = instance.Parent
+        instance.Parent = nil
+    end)
+    childVInst:OnUnmount(function(instance)
+        pcall(function()
+            instance.Parent = templateParent
+        end)
+    end)
+    return childVInst
 end
 
 --[[
@@ -480,10 +487,11 @@ end
     found, or if a function is provided, will wait until a child is found for
     which the provided callback returns true.
 
-    The following statements are equivalent:
+    The following blocks of code are equivalent:
 ```lua
+local parent = Dec.Premade()
 local child = Dec.Premade()
-local parent = Dec.Premade({}, {ChildName = child})
+parent:AddChild("ChildName", child)
 ```
 
 ```lua
@@ -493,14 +501,18 @@ local child = parent:FindChild("ChildName")
 ]]
 function VirtualInstance.__index.FindChild(
     self: VirtualInstance,
-    nameOrPredicate: string | (instance: Instance) -> ()
-): ()
+    path: string | {string}
+): VirtualInstance
     assertNotYetMounted(self)
-    table.insert(self._directives, {
-        _type = "FindChild",
-        _payload = nameOrPredicate,
-        _trace = getTrace("Dec.FindChild", 1),
-    })
+
+    -- De-sugar argument
+    local VirtualInstanceCreators = (require :: any)(
+        script.Parent.VirtualInstanceCreators)
+
+    local childVInst = VirtualInstanceCreators.Premade()
+    self:AddChild(path, childVInst)
+    
+    return childVInst
 end
 
 --[[
@@ -513,7 +525,7 @@ end
     been reconciled.
 ]]
 function VirtualInstance.new(
-    constructorType: "New" | "Clone" | "Premade",
+    constructorType: "New" | "Clone" | "Premade" | "Extract",
     constructorPayload: any?,
     defaultProperties: {[string]: CanBeObservable<any>}?,
     defaultChildMap: ChildMap?,

--- a/src/VirtualInstanceCreators.luau
+++ b/src/VirtualInstanceCreators.luau
@@ -2,6 +2,9 @@
 
 local Types = require(script.Parent.Types)
 local VirtualInstance = require(script.Parent.VirtualInstance)
+type VirtualInstance = Types.VirtualInstance
+type CanBeObservable<T> = Types.CanBeObservable<T>
+type ChildMap = Types.ChildMap
 
 local VirtualInstanceCreators = {}
 
@@ -17,8 +20,8 @@ local VirtualInstanceCreators = {}
 function VirtualInstanceCreators.New(
     className: string,
     props: {[string]: any}?,
-    children: Types.ChildMap?
-): Types.VirtualInstance
+    children: ChildMap?
+): VirtualInstance
     return VirtualInstance.new(
         "New",
         className,
@@ -38,10 +41,10 @@ end
     from a given template instance (via template:Clone()).
 ]]
 function VirtualInstanceCreators.Clone(
-    template: Instance,
+    template: CanBeObservable<Instance | VirtualInstance>,
     props: {[string]: any}?,
-    children: Types.ChildMap?
-): Types.VirtualInstance
+    children: ChildMap?
+): VirtualInstance
     return VirtualInstance.new(
         "Clone",
         template,
@@ -67,8 +70,8 @@ end
 ]]
 function VirtualInstanceCreators.Premade(
     props: {[string]: any}?,
-    children: Types.ChildMap?
-): Types.VirtualInstance
+    children: ChildMap?
+): VirtualInstance
     return VirtualInstance.new(
         "Premade",
         nil,

--- a/src/VirtualInstanceCreators.luau
+++ b/src/VirtualInstanceCreators.luau
@@ -41,7 +41,7 @@ end
     from a given template instance (via template:Clone()).
 ]]
 function VirtualInstanceCreators.Clone(
-    template: CanBeObservable<Instance | VirtualInstance>,
+    template: Instance | VirtualInstance,
     props: {[string]: any}?,
     children: ChildMap?
 ): VirtualInstance


### PR DESCRIPTION
Adds utilities that specifically target the use case of extracting templates within a premade UI tree, without having to sacrifice static visuals on the template.

- Adds VirtualInstance:FindChild(), which is sugar for :AddChild() + Dec.Premade()
- Adds VirtualInstance:ExtractChildTemplate(), which is sugar for :AddChild() + Dec.Premade() + Dec.OnMount() + Dec.OnUnmount(). Deletes / parents to nil a child template matching the input conditions, and reparents that back to the parent instance on unmount if the parent instance was not destroyed.
- VirtualInstances store node information just as they are reconciled/before they are frozen.
- ~~Dec.Clone() allows Observables and VirtualInstances as input. If the observable output is nil or virtual instance never mounts, the cloned virtual instance will also never mount.~~