### PR TITLE
Simplified Public Types

### DIFF
--- a/aftman.toml
+++ b/aftman.toml
@@ -6,5 +6,5 @@
 rojo = "rojo-rbx/rojo@7.3.0"
 selene = "Kampfkarren/selene@0.25.0"
 wally = "UpliftGames/wally@0.3.2"
-luau-lsp = "JohnnyMorganz/luau-lsp@1.22.0"
-lune = "filiptibell/lune@0.6.7"
+luau-lsp = "JohnnyMorganz/luau-lsp@1.23.0"
+lune = "filiptibell/lune@0.7.6"

--- a/src/Types.luau
+++ b/src/Types.luau
@@ -3,13 +3,13 @@
     Stores all internal and external Types for Dec
 ]]
 export type Unsubscribe = () -> ()
-export type Set<T = any> = {[T]: true}
+export type Set<T> = {[T]: true}
 
 export type MappingBinopMetamethod<Simple, Complex> =
     ((lhs: Complex, rhs: Complex) -> Complex)
     & ((lhs: Simple, rhs: Complex) -> Complex)
     & ((lhs: Complex, rhs: Simple) -> Complex)
-export type Observable<T = any> = typeof(setmetatable(
+export type Observable<T> = typeof(setmetatable(
     {} :: {
         _cachedValue: T,
         _getCurrent: () -> T,
@@ -42,7 +42,7 @@ export type Observable<T = any> = typeof(setmetatable(
         __unm: (self: Observable<T>) -> Observable<T>,
     }
 ))
-export type State<T = any> = Observable<T> & typeof(setmetatable(
+export type State<T> = Observable<T> & typeof(setmetatable(
     {} :: {
         _valueRef: {value: T},
         _notifyUpdate: (() -> ())?,
@@ -51,7 +51,7 @@ export type State<T = any> = Observable<T> & typeof(setmetatable(
         Set: (self: State<T>, T) -> (),
     }}
 ))
-export type StateRecord<T = any> = Observable<T> & typeof(setmetatable(
+export type StateRecord<T> = Observable<T> & typeof(setmetatable(
     {} :: {
         _valueRef: {value: T},
         _notifyUpdate: (() -> ())?,
@@ -64,7 +64,7 @@ export type StateRecord<T = any> = Observable<T> & typeof(setmetatable(
         Index: (self: StateRecord<T>, key: any) -> State<any>,
     }}
 ))
-export type StateDict<K = string, V = any> = Observable<{[K]: V}> & typeof(setmetatable(
+export type StateDict<K, V> = Observable<{[K]: V}> & typeof(setmetatable(
     {} :: {
         _valueRef: {value: {[K]: V}},
         _notifyUpdate: (() -> ())?,
@@ -78,7 +78,7 @@ export type StateDict<K = string, V = any> = Observable<{[K]: V}> & typeof(setme
         Index: (self: StateDict<K, V>, key: K) -> State<V>,
     }}
 ))
-export type EasedObject<T = any> = Observable<T> & typeof(setmetatable(
+export type EasedObject<T> = Observable<T> & typeof(setmetatable(
     {} :: {
         _target: Observable<T>,
         _easingFrame: any,
@@ -89,15 +89,15 @@ export type EasedObject<T = any> = Observable<T> & typeof(setmetatable(
         ResetVelocity: (self: EasedObject<T>) -> (),
     }}
 ))
-export type Spring<T = any> = EasedObject<T> & typeof(setmetatable(
+export type Spring<T> = EasedObject<T> & typeof(setmetatable(
     {} :: {
         _angularFrequency: any, -- CanBeObservable<number>
     },
     {} :: {__index: { }}
 ))
 export type AngleSpring<T> = Spring<T>
-export type IntSpring<T = any> = Spring<T>
-export type EasedValue<T = any> = EasedObject<T> & typeof(setmetatable(
+export type IntSpring<T> = Spring<T>
+export type EasedValue<T> = EasedObject<T> & typeof(setmetatable(
     {} :: {
         _info: TweenInfo,
     },

--- a/src/init.luau
+++ b/src/init.luau
@@ -19,14 +19,14 @@ local Root = require(script.Reconciler.Root)
 local Observable = require(script.Observables.Observable)
 
 export type Unsubscribe = Types.Unsubscribe
-export type Observable<T> = Types.Observable<T>
-export type State<T> = Types.State<T>
-export type Record<T> = Types.StateRecord<T>
-export type Dict<T> = Types.StateDict<T>
-export type Spring<T> = Types.Spring<T>
-export type AngleSpring<T> = Types.AngleSpring<T>
-export type IntSpring<T> = Types.IntSpring<T>
-export type EasedValue<T> = Types.EasedValue<T>
+export type Observable<T = any> = Types.Observable<T>
+export type State<T = any> = Types.State<T>
+export type Record<T = {[any]: any}> = Types.StateRecord<T>
+export type Dict<K = string, V = any> = Types.StateDict<K, V>
+export type Spring<T = any> = Types.Spring<T>
+export type AngleSpring<T = any> = Types.AngleSpring<T>
+export type IntSpring<T = any> = Types.IntSpring<T>
+export type EasedValue<T = any> = Types.EasedValue<T>
 export type Alpha = Types.Alpha
 export type BaseTimer = Types.BaseTimer
 export type Stopwatch = Types.Stopwatch

--- a/testing_proof_checksum.txt
+++ b/testing_proof_checksum.txt
@@ -1,1 +1,1 @@
-2d31de06_112_0_0_success
+177feb25_112_0_0_success


### PR DESCRIPTION
Greatly simplifies the complexity of public types by

- Removing the presence of intersection types
- Uses full explicit types for inherited objects
- Fixes operator overload support to allow for observable classes to operate with other observable subclasses via math.
- Adds an "Inherit" utility function for reducing inheritance boilerplate currently present in the subclasses.