### PR TITLE
Fix Edge cases for mounting VirtualInstance References

### DIFF
--- a/src/Reconciler/ApplyBasicDirectives/ApplyPropertyMapThrows.luau
+++ b/src/Reconciler/ApplyBasicDirectives/ApplyPropertyMapThrows.luau
@@ -93,13 +93,29 @@ local function ApplyPropertyMapThrows(
             })
         elseif typeof(value) == "table" then
             if value._dectype == "Observable" then
+                local instanceRefCleanup: (() -> ())? = nil
                 table.insert(
                     reconciledUnsubs,
-                    value:Subscribe(function(current)
-                        instance[key] = applyNilSymbol(current)
-                    end)
+                    value:Subscribe(function(current: any)
+                        if instanceRefCleanup then
+                            instanceRefCleanup()
+                            instanceRefCleanup = nil
+                        end
+
+                        if current == NilSymbol then
+                            instance[key] = nil
+                        elseif typeof(current) == "table"
+                        and current._dectype == "VirtualInstance" then
+                            instanceRefCleanup = ApplyReferenceToVInst(
+                                instance,
+                                key,
+                                current
+                            )
+                        else
+                            instance[key] = applyNilSymbol(current)
+                        end
+                    end, true)
                 )
-                instance[key] = applyNilSymbol(value:Current())
             elseif value._dectype == "VirtualInstance" then
                 local cleanup = ApplyReferenceToVInst(
                     instance,

--- a/testing_proof_checksum.txt
+++ b/testing_proof_checksum.txt
@@ -1,1 +1,1 @@
-1d4b216c_126_0_0_success
+6ffbbfc_127_0_0_success

--- a/tests/Reconciler/Directives.SetProperties.spec.luau
+++ b/tests/Reconciler/Directives.SetProperties.spec.luau
@@ -108,5 +108,33 @@ return function()
 
             expect(host.CurrentCamera).to.equal(nil)
         end)
+        it("Sets an observable reference to VirtualInstance", function()
+            local host = Instance.new("ViewportFrame")
+            local camera = Instance.new("Camera")
+            camera.Parent = host
+            host.CurrentCamera = camera
+
+            local observableReference = Dec.State(Dec.Nil :: any)
+            local cameraVInst = Dec.Premade("Camera")
+            local virtualInstance = Dec.Premade("ViewportFrame", {
+                CurrentCamera = observableReference
+            }, {
+                Camera = cameraVInst
+            })
+
+            expect(host.CurrentCamera).to.equal(camera)
+
+            Dec.Root(host):Render(virtualInstance)
+
+            expect(host.CurrentCamera).to.equal(nil)
+
+            observableReference:Set(cameraVInst)
+
+            expect(host.CurrentCamera).to.equal(camera)
+
+            observableReference:Set(Dec.Nil)
+
+            expect(host.CurrentCamera).to.equal(nil)
+        end)
     end)
 end


### PR DESCRIPTION
- Fixes an edge case when mounting a _observable_ reference to a virtual instance

To exemplify this edge case—this would work as expected: 
```lua
local camera = Dec.New("Camera")
local viewportFrame = Dec.Premade({
    CurrentCamera = camera
}, {camera, ...})
```

However, this did not work:
```lua
local camera = Dec.New("Camera")
local currentCameraState = Dec.State(camera :: any)
local viewportFrame = Dec.Premade({
    CurrentCamera = currentCameraState
}, {camera, ...})
-- . . .
currentCameraState:Set(Dec.Nil)
```

This PR adds a test cases for observable references to VirtualInstances, resolving to its rendered instance on mount via a SetProperties directive.